### PR TITLE
feat(about-card): add AboutCard component and test

### DIFF
--- a/src/components/AboutCard/AboutCard.test.tsx
+++ b/src/components/AboutCard/AboutCard.test.tsx
@@ -1,0 +1,35 @@
+import 'jsdom-global/register';
+import * as React from 'react';
+import { mount } from 'enzyme';
+import AboutCard from './AboutCard';
+
+describe('AboutCard', () => {
+  it('has title, descriptionTitle and description', () => {
+    let wrap = mount<typeof AboutCard>(
+      <AboutCard
+        title="Title"
+        description="Description"
+        descriptionTitle="Description title"
+      />
+    );
+    expect(wrap.find('h3').text()).toEqual('Title');
+    expect(wrap.find('h6').text()).toEqual('Description title');
+    expect(wrap.find('p').text()).toEqual('Description');
+  });
+
+  it('has image as child', () => {
+    let wrap = mount<typeof AboutCard>(
+      <AboutCard
+        title="Title"
+        description="Description"
+        descriptionTitle="Description title"
+      >
+        <img src="fakePathToImage" />
+      </AboutCard>
+    );
+    expect(wrap.find('img').get(0).props).toHaveProperty(
+      'src',
+      'fakePathToImage'
+    );
+  });
+});

--- a/src/components/AboutCard/AboutCard.tsx
+++ b/src/components/AboutCard/AboutCard.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {
+  Card as CardMUI,
+  CardContent,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+
+const useStyles = makeStyles({
+  card: {
+    borderRadius: 4,
+    display: 'flex',
+    flexDirection: 'column',
+    flexGrow: 1,
+    padding: '1.6rem 2rem',
+  },
+  cardContent: {
+    flexGrow: 1,
+  },
+  title: { color: '#F2F5F7' },
+});
+
+export type AboutCardProps = {
+  title: string;
+  /**
+   * .
+   */
+  description?: string;
+  /**
+   * .
+   */
+  descriptionTitle?: string;
+  /**
+   *
+   */
+  children?: string | undefined;
+};
+
+const AboutCard: React.FC<AboutCardProps> = ({
+  title,
+  description,
+  descriptionTitle,
+  children,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <CardMUI className={classes.card}>
+      <CardContent className={classes.cardContent}>
+        <Typography gutterBottom variant="h3">
+          {title}
+        </Typography>
+        <Typography variant="subtitle1">{descriptionTitle}</Typography>
+        <Typography variant="body2">{description}</Typography>
+      </CardContent>
+      {children}
+    </CardMUI>
+  );
+};
+
+export default AboutCard;

--- a/src/components/AboutCard/AboutCard.tsx
+++ b/src/components/AboutCard/AboutCard.tsx
@@ -22,18 +22,9 @@ const useStyles = makeStyles({
 
 export type AboutCardProps = {
   title: string;
-  /**
-   * .
-   */
   description?: string;
-  /**
-   * .
-   */
   descriptionTitle?: string;
-  /**
-   *
-   */
-  children?: string | undefined;
+  children?: React.ReactNode | undefined;
 };
 
 const AboutCard: React.FC<AboutCardProps> = ({

--- a/src/components/AboutCard/index.ts
+++ b/src/components/AboutCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AboutCard';


### PR DESCRIPTION
AboutCard component makes it easier to build presentation cards in a landing page or dashboard. Using this component is done by proving the `props` below, the `title` prop is mandatory whilst the other props are optional.

```
  title: string;
  description?: string;
  descriptionTitle?: string;
  children?: React.ReactNode | undefined;
```