### PR TITLE
feat(dashboard-card): add DashboardCard component and test

### DIFF
--- a/src/components/DashboardCard/DashboardCard.test.tsx
+++ b/src/components/DashboardCard/DashboardCard.test.tsx
@@ -4,12 +4,11 @@ import { mount } from 'enzyme';
 import DashboardCard from './DashboardCard';
 
 describe('DashboardCard', () => {
-  it('has title, descriptionTitle and description', () => {
+  it('has title and description', () => {
     let wrap = mount<typeof DashboardCard>(
       <DashboardCard description="Description" title="Title" />
     );
-    expect(wrap.find('h3').text()).toEqual('Title');
-    expect(wrap.find('h6').text()).toEqual('Description title');
+    expect(wrap.find('h6').text()).toEqual('Title');
     expect(wrap.find('p').text()).toEqual('Description');
   });
 
@@ -18,6 +17,20 @@ describe('DashboardCard', () => {
       <DashboardCard description="Description" title="Title">
         <img src="fakePathToImage" />
       </DashboardCard>
+    );
+    expect(wrap.find('img').get(0).props).toHaveProperty(
+      'src',
+      'fakePathToImage'
+    );
+  });
+
+  it('has image as header child', () => {
+    let wrap = mount<typeof DashboardCard>(
+      <DashboardCard
+        description="Description"
+        headerChildren={<img src="fakePathToImage" />}
+        title="Title"
+      />
     );
     expect(wrap.find('img').get(0).props).toHaveProperty(
       'src',

--- a/src/components/DashboardCard/DashboardCard.test.tsx
+++ b/src/components/DashboardCard/DashboardCard.test.tsx
@@ -1,0 +1,27 @@
+import 'jsdom-global/register';
+import * as React from 'react';
+import { mount } from 'enzyme';
+import DashboardCard from './DashboardCard';
+
+describe('DashboardCard', () => {
+  it('has title, descriptionTitle and description', () => {
+    let wrap = mount<typeof DashboardCard>(
+      <DashboardCard description="Description" title="Title" />
+    );
+    expect(wrap.find('h3').text()).toEqual('Title');
+    expect(wrap.find('h6').text()).toEqual('Description title');
+    expect(wrap.find('p').text()).toEqual('Description');
+  });
+
+  it('has image as child', () => {
+    let wrap = mount<typeof DashboardCard>(
+      <DashboardCard description="Description" title="Title">
+        <img src="fakePathToImage" />
+      </DashboardCard>
+    );
+    expect(wrap.find('img').get(0).props).toHaveProperty(
+      'src',
+      'fakePathToImage'
+    );
+  });
+});

--- a/src/components/DashboardCard/DashboardCard.tsx
+++ b/src/components/DashboardCard/DashboardCard.tsx
@@ -1,51 +1,119 @@
-import * as React from 'react';
-import {
-  Card as CardMUI,
-  CardContent,
-  Typography,
-  makeStyles,
-} from '@material-ui/core';
+import React from 'react';
+import { Box, Typography, makeStyles } from '@material-ui/core';
+import AspectRatioIcon from '@material-ui/icons/AspectRatio';
 
-const useStyles = makeStyles({
-  card: {
-    borderRadius: 4,
+const useStyles = makeStyles((theme) => ({
+  cardHeader: {
+    backgroundColor: '#FFFFFF',
+    borderBottom: '1px solid #DBE4E9',
+    padding: '2px 12px',
+    position: 'sticky',
     display: 'flex',
-    flexDirection: 'column',
+    top: 0,
+    zIndex: 1,
+  },
+  cardWrapper: {
     flexGrow: 1,
-    padding: '1.6rem 2rem',
+    boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.16)',
+    backgroundColor: '#FFFFFF',
+    border: '1px solid #DBE4E9',
+    borderRadius: 4,
+    height: '100%',
+    position: 'relative',
+  },
+  cardWrapperAbsolute: {
+    flexGrow: 1,
+    boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.16)',
+    backgroundColor: '#FFFFFF',
+    border: '1px solid #DBE4E9',
+    borderRadius: 4,
+    height: '100%',
+    width: '100%',
+    position: 'absolute',
+    zIndex: 20,
+    top: 0,
+    left: 0,
   },
   cardContent: {
-    flexGrow: 1,
+    width: '100%',
   },
-  title: { color: '#F2F5F7' },
-});
+  overlay: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: 'rgba(11, 69, 102, .5)',
+    zIndex: 10,
+    position: 'absolute',
+    top: 0,
+    left: 0,
+  },
+}));
 
 export type DashboardCardProps = {
-  title: string;
-  description?: string;
-  descriptionTitle?: string;
   children?: React.ReactNode | undefined;
+  description?: string;
+  disabled;
+  headerChildren: React.ReactNode | undefined;
+  style: any;
+  title: string;
 };
 
 const DashboardCard: React.FC<DashboardCardProps> = ({
-  title,
-  description,
-  descriptionTitle,
   children,
+  description,
+  disabled,
+  headerChildren,
+  style,
+  title,
 }) => {
+  const [expand, setExpand] = React.useState(false);
   const classes = useStyles();
 
+  const expandCard = () => {
+    setExpand(!expand);
+    window.dispatchEvent(new Event('resize'));
+  };
+
   return (
-    <CardMUI className={classes.card}>
-      <CardContent className={classes.cardContent}>
-        <Typography gutterBottom variant="h3">
-          {title}
-        </Typography>
-        <Typography variant="subtitle1">{descriptionTitle}</Typography>
-        <Typography variant="body2">{description}</Typography>
-      </CardContent>
+    <Box
+      className={expand ? classes.cardWrapperAbsolute : classes.cardWrapper}
+      style={{
+        ...style,
+        transition: 'all .5s ease',
+        overflow: !disabled ? 'auto' : 'hidden',
+      }}
+    >
+      {disabled && <Box className={classes.overlay}></Box>}
+
+      <Box
+        className={classes.cardHeader}
+        alignItems="center"
+        justifyContent="flex-start"
+      >
+        <Box mr={2}>
+          <Typography
+            variant="subtitle1"
+            style={{ fontSize: 16 }}
+            color="primary"
+          >
+            {title}
+          </Typography>
+          <Typography variant="body2" style={{ color: '#86A2B3' }}>
+            {description}
+          </Typography>
+        </Box>
+        <Box ml="auto" display="flex">
+          {headerChildren}
+        </Box>
+        <Box ml={2}>
+          <AspectRatioIcon
+            color="primary"
+            style={{ height: 24, width: 'auto', cursor: 'pointer' }}
+            onClick={() => expandCard()}
+          />
+        </Box>
+      </Box>
       {children}
-    </CardMUI>
+    </Box>
   );
 };
 

--- a/src/components/DashboardCard/DashboardCard.tsx
+++ b/src/components/DashboardCard/DashboardCard.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import {
+  Card as CardMUI,
+  CardContent,
+  Typography,
+  makeStyles,
+} from '@material-ui/core';
+
+const useStyles = makeStyles({
+  card: {
+    borderRadius: 4,
+    display: 'flex',
+    flexDirection: 'column',
+    flexGrow: 1,
+    padding: '1.6rem 2rem',
+  },
+  cardContent: {
+    flexGrow: 1,
+  },
+  title: { color: '#F2F5F7' },
+});
+
+export type DashboardCardProps = {
+  title: string;
+  description?: string;
+  descriptionTitle?: string;
+  children?: React.ReactNode | undefined;
+};
+
+const DashboardCard: React.FC<DashboardCardProps> = ({
+  title,
+  description,
+  descriptionTitle,
+  children,
+}) => {
+  const classes = useStyles();
+
+  return (
+    <CardMUI className={classes.card}>
+      <CardContent className={classes.cardContent}>
+        <Typography gutterBottom variant="h3">
+          {title}
+        </Typography>
+        <Typography variant="subtitle1">{descriptionTitle}</Typography>
+        <Typography variant="body2">{description}</Typography>
+      </CardContent>
+      {children}
+    </CardMUI>
+  );
+};
+
+export default DashboardCard;

--- a/src/components/DashboardCard/DashboardCard.tsx
+++ b/src/components/DashboardCard/DashboardCard.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import * as React from 'react';
 import { Box, Typography, makeStyles } from '@material-ui/core';
 import AspectRatioIcon from '@material-ui/icons/AspectRatio';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles({
   cardHeader: {
     backgroundColor: '#FFFFFF',
     borderBottom: '1px solid #DBE4E9',
@@ -46,7 +46,7 @@ const useStyles = makeStyles((theme) => ({
     top: 0,
     left: 0,
   },
-}));
+});
 
 export type DashboardCardProps = {
   children?: React.ReactNode | undefined;
@@ -66,7 +66,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
   title,
 }) => {
   const classes = useStyles();
-  const [expand, setExpand] = React.useState(false);
+  const [expand, setExpand] = React.useState<boolean | undefined>(false);
 
   const expandCard = () => {
     setExpand(!expand);
@@ -91,9 +91,9 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
       >
         <Box mr={2}>
           <Typography
-            variant="subtitle1"
-            style={{ fontSize: 16 }}
             color="primary"
+            style={{ fontSize: 16 }}
+            variant="subtitle1"
           >
             {title}
           </Typography>

--- a/src/components/DashboardCard/DashboardCard.tsx
+++ b/src/components/DashboardCard/DashboardCard.tsx
@@ -51,22 +51,22 @@ const useStyles = makeStyles((theme) => ({
 export type DashboardCardProps = {
   children?: React.ReactNode | undefined;
   description?: string;
-  disabled;
-  headerChildren: React.ReactNode | undefined;
-  style: any;
+  disabled?: boolean;
+  headerChildren?: React.ReactNode | undefined;
+  style?: any;
   title: string;
 };
 
 const DashboardCard: React.FC<DashboardCardProps> = ({
   children,
   description,
-  disabled,
+  disabled = false,
   headerChildren,
   style,
   title,
 }) => {
-  const [expand, setExpand] = React.useState(false);
   const classes = useStyles();
+  const [expand, setExpand] = React.useState(false);
 
   const expandCard = () => {
     setExpand(!expand);

--- a/src/components/DashboardCard/index.ts
+++ b/src/components/DashboardCard/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DashboardCard';


### PR DESCRIPTION
The DashboardCard component makes it easier to build dashboard layouts by wrapping other components. Using this component is done by proving the props below, the title prop is mandatory whilst the other props are optional.

```
  children?: React.ReactNode | undefined;
  description?: string;
  disabled?: boolean;
  headerChildren?: React.ReactNode | undefined;
  style?: any;
  title: string;
```