### PR TITLE
feat(SidebarControl): add SidebarControl component and test

### DIFF
--- a/src/components/SidebarControl/SidebarControl.test.tsx
+++ b/src/components/SidebarControl/SidebarControl.test.tsx
@@ -1,12 +1,84 @@
 import 'jsdom-global/register';
 import * as React from 'react';
 import { mount } from 'enzyme';
+import {
+  ExpandMore as ExpandMoreIcon,
+  ExpandLess as ExpandLessIcon,
+} from '@material-ui/icons';
 import SidebarControl from './SidebarControl';
 
 describe('SidebarControl', () => {
-  it('has default elements', () => {
-    let wrap = mount<typeof SidebarControl>(
-      <SidebarControl openSidebar={true} />
+  it('shows the close icons when sidebar is opened for desktop and mobile', () => {
+    let desktop = mount<typeof SidebarControl>(
+      <SidebarControl openSidebar={true} mobile={false} />
     );
+    expect(desktop.find('[data-testid="sidebar-close"]').exists()).toEqual(
+      true
+    );
+    expect(desktop.find('[data-testid="sidebar-open"]').exists()).toEqual(
+      false
+    );
+    expect(desktop.find('[data-testid="expand-close"]').exists()).toEqual(
+      false
+    );
+    expect(desktop.find('[data-testid="expand-open"]').exists()).toEqual(false);
+
+    let mobile = mount<typeof SidebarControl>(
+      <SidebarControl openSidebar={true} mobile={true} />
+    );
+    expect(mobile.find('[data-testid="sidebar-close"]').exists()).toEqual(
+      false
+    );
+    expect(mobile.find('[data-testid="sidebar-open"]').exists()).toEqual(false);
+    expect(mobile.find('[data-testid="expand-close"]').exists()).toEqual(true);
+    expect(mobile.find('[data-testid="expand-open"]').exists()).toEqual(false);
+  });
+
+  it('shows the open icons when sidebar is closed for desktop and mobile', () => {
+    let desktop = mount<typeof SidebarControl>(
+      <SidebarControl openSidebar={false} mobile={false} />
+    );
+    expect(desktop.find('[data-testid="sidebar-open"]').exists()).toEqual(true);
+    expect(desktop.find('[data-testid="sidebar-close"]').exists()).toEqual(
+      false
+    );
+    expect(desktop.find('[data-testid="expand-close"]').exists()).toEqual(
+      false
+    );
+    expect(desktop.find('[data-testid="expand-open"]').exists()).toEqual(false);
+
+    let mobile = mount<typeof SidebarControl>(
+      <SidebarControl openSidebar={false} mobile={true} />
+    );
+    expect(mobile.find('[data-testid="sidebar-close"]').exists()).toEqual(
+      false
+    );
+    expect(mobile.find('[data-testid="sidebar-open"]').exists()).toEqual(false);
+    expect(mobile.find('[data-testid="expand-close"]').exists()).toEqual(false);
+    expect(mobile.find('[data-testid="expand-open"]').exists()).toEqual(true);
+  });
+
+  it('has icons for switching tabs', () => {
+    let desktop = mount<typeof SidebarControl>(
+      <SidebarControl
+        openSidebar={false}
+        mobile={false}
+        icons={[
+          {
+            id: 1,
+            component: ExpandMoreIcon,
+            tooltip: 'Tab 1',
+          },
+          {
+            id: 2,
+            component: ExpandLessIcon,
+            tooltip: 'Tab 2',
+          },
+        ]}
+      />
+    );
+    expect(desktop.find('[data-testid="tab-1"]').exists()).toEqual(true);
+    expect(desktop.find('[data-testid="tab-2"]').exists()).toEqual(true);
+    expect(desktop.find('[data-testid="tab-3"]').exists()).toEqual(false);
   });
 });

--- a/src/components/SidebarControl/SidebarControl.test.tsx
+++ b/src/components/SidebarControl/SidebarControl.test.tsx
@@ -1,0 +1,12 @@
+import 'jsdom-global/register';
+import * as React from 'react';
+import { mount } from 'enzyme';
+import SidebarControl from './SidebarControl';
+
+describe('SidebarControl', () => {
+  it('has default elements', () => {
+    let wrap = mount<typeof SidebarControl>(
+      <SidebarControl openSidebar={true} />
+    );
+  });
+});

--- a/src/components/SidebarControl/SidebarControl.tsx
+++ b/src/components/SidebarControl/SidebarControl.tsx
@@ -20,22 +20,25 @@ export const useStyle = makeStyles({
   },
 });
 
-const icons: Array<{ id: number; component: React.FC; tooltip: string }> = [
-  // {
-  //   id: 1,
-  //   component: ExpandMoreIcon,
-  //   tooltip: "Information",
-  // },
-];
+// icons example
+// const icons: Array<{ id: number; component: React.FC; tooltip: string }> = [
+//   {
+//     id: 1,
+//     component: ExpandMoreIcon,
+//     tooltip: 'Information',
+//   },
+// ];
 
 type SidebarControlProps = {
   handleToggleSidebar?: () => void;
+  icons?: Array<{ id: number; component: React.FC; tooltip: string }>;
   mobile?: boolean;
   openSidebar?: boolean;
 };
 
 const SidebarControl: React.FC<SidebarControlProps> = ({
   handleToggleSidebar,
+  icons,
   mobile = false,
   openSidebar,
 }) => {
@@ -75,13 +78,14 @@ const SidebarControl: React.FC<SidebarControlProps> = ({
         alignItems="center"
         style={{ height: 'calc(100% - 72px)' }}
       >
-        {icons.map(({ id, component: Component, tooltip }) => (
-          <Tooltip placement="left" key={id} title={tooltip}>
-            <IconButton onClick={() => setTab(id)}>
-              <Component />
-            </IconButton>
-          </Tooltip>
-        ))}
+        {icons &&
+          icons.map(({ id, component: Component, tooltip }) => (
+            <Tooltip placement="left" key={id} title={tooltip}>
+              <IconButton onClick={() => setTab(id)}>
+                <Component />
+              </IconButton>
+            </Tooltip>
+          ))}
       </Grid>
     </Box>
   );

--- a/src/components/SidebarControl/SidebarControl.tsx
+++ b/src/components/SidebarControl/SidebarControl.tsx
@@ -1,92 +1,88 @@
 import * as React from 'react';
-import { Box, Grid, Typography } from '@material-ui/core';
+import { Box, Grid, IconButton, Tooltip, makeStyles } from '@material-ui/core';
+import {
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+  ExpandLess as ExpandLessIcon,
+  ExpandMore as ExpandMoreIcon,
+} from '@material-ui/icons';
 
-const containerStyle = {
-  padding: 16,
-};
+export const useStyle = makeStyles({
+  icon: {
+    backgroundColor: '#fff',
+    height: 22,
+  },
+  activeIcon: {
+    backgroundColor: '#0b4566',
+    '& path': {
+      fill: '#fff',
+    },
+  },
+});
 
-const mainTitleStyle = {
-  fontSize: 20,
-  fontWeight: 500,
-  // color: '#0b4566',
-  //
-};
-
-// const useStyles = makeStyles((theme: Theme) =>
-//   createStyles({
-//     container: {
-//       padding: 16,
-//     },
-//     mainTitle: {
-//       fontSize: 20,
-//       fontWeight: 500,
-//       color: '#0b4566',
-//     },
-//   })
-// );
+const icons: Array<{ id: number; component: React.FC; tooltip: string }> = [
+  // {
+  //   id: 1,
+  //   component: ExpandMoreIcon,
+  //   tooltip: "Information",
+  // },
+];
 
 type SidebarControlProps = {
-  title: string;
-  titleColor?: string;
-  subTitle?: Array<string>;
-  subTitleColor?: string;
-  image?: string;
-  imageWidth?: number;
-  backgroundColor?: string;
-  bottomBorderSize?: string | number;
-  bottomBorderColor?: string;
+  handleToggleSidebar?: () => void;
+  mobile?: boolean;
+  openSidebar?: boolean;
 };
+
 const SidebarControl: React.FC<SidebarControlProps> = ({
-  title = 'Current title',
-  subTitle = [''],
-  image,
-  imageWidth = 38,
-  backgroundColor = '#FFFFFF',
-  titleColor = '#0b4566',
-  subTitleColor = '#86a2b3',
-  bottomBorderSize,
-  bottomBorderColor,
+  handleToggleSidebar,
+  mobile = false,
+  openSidebar,
 }) => {
-  // const classes = useStyles({} as StyledProps);
+  const classes = useStyle();
+  const [tab, setTab] = React.useState<number | undefined>();
+
   return (
     <Box
-      style={{
-        backgroundColor,
-        borderBottom: `${bottomBorderSize}px solid ${bottomBorderColor}`,
-        ...containerStyle,
-      }}
+      flexGrow={1}
+      display="flex"
+      flexDirection={mobile === true ? 'row' : 'column'}
+      style={{ overflowY: 'auto', height: '100%' }}
     >
-      <Grid container spacing={0} justify="space-between">
-        <Grid item xs={10}>
-          <Typography
-            style={{ color: titleColor, ...mainTitleStyle }}
-            variant={'h2'}
-          >
-            {title}
-          </Typography>
-        </Grid>
-        {image && (
-          <Grid item>
-            <img src={image} alt="DHI Logo" style={{ width: imageWidth }} />
-          </Grid>
-        )}
+      <Box>
+        <IconButton
+          onClick={handleToggleSidebar}
+          style={{ backgroundColor: '#fff' }}
+        >
+          {openSidebar === true && mobile !== true && (
+            <ChevronRightIcon className={classes.icon} color="primary" />
+          )}
+          {openSidebar === false && mobile !== true && (
+            <ChevronLeftIcon className={classes.icon} color="primary" />
+          )}
+          {openSidebar === true && mobile === true && (
+            <ExpandMoreIcon className={classes.icon} color="primary" />
+          )}
+          {openSidebar === false && mobile === true && (
+            <ExpandLessIcon className={classes.icon} color="primary" />
+          )}
+        </IconButton>
+      </Box>
+      <Grid
+        container
+        direction="column"
+        justify="center"
+        alignItems="center"
+        style={{ height: 'calc(100% - 72px)' }}
+      >
+        {icons.map(({ id, component: Component, tooltip }) => (
+          <Tooltip placement="left" key={id} title={tooltip}>
+            <IconButton onClick={() => setTab(id)}>
+              <Component />
+            </IconButton>
+          </Tooltip>
+        ))}
       </Grid>
-      {(subTitle || subTitle.length > 0) && (
-        <>
-          {subTitle.map((text: string, index: number) => {
-            return (
-              <Typography
-                key={`subtitle-${index}`}
-                style={{ color: subTitleColor }}
-                color="secondary"
-                variant="h4"
-              >
-                {text}
-              </Typography>
-            );
-          })}
-        </>
-      )}
     </Box>
   );
 };

--- a/src/components/SidebarControl/SidebarControl.tsx
+++ b/src/components/SidebarControl/SidebarControl.tsx
@@ -58,16 +58,32 @@ const SidebarControl: React.FC<SidebarControlProps> = ({
           style={{ backgroundColor: '#fff' }}
         >
           {openSidebar === true && mobile !== true && (
-            <ChevronRightIcon className={classes.icon} color="primary" />
+            <ChevronRightIcon
+              data-testid="sidebar-close"
+              className={classes.icon}
+              color="primary"
+            />
           )}
           {openSidebar === false && mobile !== true && (
-            <ChevronLeftIcon className={classes.icon} color="primary" />
+            <ChevronLeftIcon
+              data-testid="sidebar-open"
+              className={classes.icon}
+              color="primary"
+            />
           )}
           {openSidebar === true && mobile === true && (
-            <ExpandMoreIcon className={classes.icon} color="primary" />
+            <ExpandMoreIcon
+              data-testid="expand-close"
+              className={classes.icon}
+              color="primary"
+            />
           )}
           {openSidebar === false && mobile === true && (
-            <ExpandLessIcon className={classes.icon} color="primary" />
+            <ExpandLessIcon
+              data-testid="expand-open"
+              className={classes.icon}
+              color="primary"
+            />
           )}
         </IconButton>
       </Box>
@@ -81,7 +97,7 @@ const SidebarControl: React.FC<SidebarControlProps> = ({
         {icons &&
           icons.map(({ id, component: Component, tooltip }) => (
             <Tooltip placement="left" key={id} title={tooltip}>
-              <IconButton onClick={() => setTab(id)}>
+              <IconButton data-testid={`tab-${id}`} onClick={() => setTab(id)}>
                 <Component />
               </IconButton>
             </Tooltip>

--- a/src/components/SidebarControl/SidebarControl.tsx
+++ b/src/components/SidebarControl/SidebarControl.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react';
+import { Box, Grid, Typography } from '@material-ui/core';
+
+const containerStyle = {
+  padding: 16,
+};
+
+const mainTitleStyle = {
+  fontSize: 20,
+  fontWeight: 500,
+  // color: '#0b4566',
+  //
+};
+
+// const useStyles = makeStyles((theme: Theme) =>
+//   createStyles({
+//     container: {
+//       padding: 16,
+//     },
+//     mainTitle: {
+//       fontSize: 20,
+//       fontWeight: 500,
+//       color: '#0b4566',
+//     },
+//   })
+// );
+
+type SidebarControlProps = {
+  title: string;
+  titleColor?: string;
+  subTitle?: Array<string>;
+  subTitleColor?: string;
+  image?: string;
+  imageWidth?: number;
+  backgroundColor?: string;
+  bottomBorderSize?: string | number;
+  bottomBorderColor?: string;
+};
+const SidebarControl: React.FC<SidebarControlProps> = ({
+  title = 'Current title',
+  subTitle = [''],
+  image,
+  imageWidth = 38,
+  backgroundColor = '#FFFFFF',
+  titleColor = '#0b4566',
+  subTitleColor = '#86a2b3',
+  bottomBorderSize,
+  bottomBorderColor,
+}) => {
+  // const classes = useStyles({} as StyledProps);
+  return (
+    <Box
+      style={{
+        backgroundColor,
+        borderBottom: `${bottomBorderSize}px solid ${bottomBorderColor}`,
+        ...containerStyle,
+      }}
+    >
+      <Grid container spacing={0} justify="space-between">
+        <Grid item xs={10}>
+          <Typography
+            style={{ color: titleColor, ...mainTitleStyle }}
+            variant={'h2'}
+          >
+            {title}
+          </Typography>
+        </Grid>
+        {image && (
+          <Grid item>
+            <img src={image} alt="DHI Logo" style={{ width: imageWidth }} />
+          </Grid>
+        )}
+      </Grid>
+      {(subTitle || subTitle.length > 0) && (
+        <>
+          {subTitle.map((text: string, index: number) => {
+            return (
+              <Typography
+                key={`subtitle-${index}`}
+                style={{ color: subTitleColor }}
+                color="secondary"
+                variant="h4"
+              >
+                {text}
+              </Typography>
+            );
+          })}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default SidebarControl;

--- a/src/components/SidebarControl/index.ts
+++ b/src/components/SidebarControl/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SidebarControl';


### PR DESCRIPTION
The SidebarControl component is a container that helps users navigate with ease in a sidebar. Using this component is done by proving the props below, the title prop is mandatory whilst the other props are optional.

```
type SidebarControlProps = {
  handleToggleSidebar?: () => void;
  icons?: Array<{ id: number; component: React.FC; tooltip: string }>;
  mobile?: boolean;
  openSidebar?: boolean;
};
```