### PR TITLE
fix(DashboardCard): Center expand more icon

### DIFF
--- a/src/components/DashboardCard/DashboardCard.tsx
+++ b/src/components/DashboardCard/DashboardCard.tsx
@@ -104,7 +104,7 @@ const DashboardCard: React.FC<DashboardCardProps> = ({
         <Box ml="auto" display="flex">
           {headerChildren}
         </Box>
-        <Box ml={2}>
+        <Box ml={2} display="flex">
           <AspectRatioIcon
             color="primary"
             style={{ height: 24, width: 'auto', cursor: 'pointer' }}


### PR DESCRIPTION
This PR centers the expandMore icon in the DashboardCard component. Close #49 

![954f0e40680622566fa85068610fcfe3](https://user-images.githubusercontent.com/30385700/97271942-88a65b80-1831-11eb-97b6-c0e931da7e79.png)
